### PR TITLE
Update bdsim.rb

### DIFF
--- a/bdsim.rb
+++ b/bdsim.rb
@@ -7,8 +7,11 @@ class Bdsim < Formula
 
   depends_on "cmake" => :build
   depends_on "bison"
+  depends_on "clhep"
+  depends_on "flex"
   depends_on "ulb-metronu/metronu/root"
   depends_on "ulb-metronu/metronu/geant4"
+  depends_on "qt" => :optional
 
   skip_clean "bin"
 

--- a/bdsim.rb
+++ b/bdsim.rb
@@ -9,6 +9,7 @@ class Bdsim < Formula
   depends_on "bison"
   depends_on "clhep"
   depends_on "flex"
+  depends_on "boost"
   depends_on "ulb-metronu/metronu/root"
   depends_on "ulb-metronu/metronu/geant4"
   depends_on "qt" => :optional

--- a/bdsim.rb
+++ b/bdsim.rb
@@ -1,166 +1,34 @@
 class Bdsim < Formula
-  desc "Object oriented framework for large scale data analysis"
-  homepage "https://root.cern.ch/"
-  url "https://root.cern.ch/download/root_v6.18.00.source.tar.gz"
-  version "6.18.00"
-  sha256 "e6698d6cfe585f186490b667163db65e7d1b92a2447658d77fa831096383ea71"
-  head "https://github.com/root-project/root.git"
-
-  bottle do
-    sha256 "40cec3904743cdea491c2902a3a02ed3ed37cebc51e4c06422581bc4db55619e" => :mojave
-    sha256 "742151f6e2c88871ce2fc78523c52d760d24e4f9e13c65463bbd5461dad42bd1" => :high_sierra
-    sha256 "5d57207635e536423a9b8e45ccc2cff38eb582fb126fe5163f1cf76f9f660deb" => :sierra
-  end
-
-  # https://github.com/Homebrew/homebrew-core/issues/30726
-  # strings libCling.so | grep Xcode:
-  #  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1
-  #  /Applications/Xcode.app/Contents/Developer
-  pour_bottle? do
-    reason "The bottle hardcodes locations inside Xcode.app"
-    satisfy do
-      MacOS::Xcode.installed? &&
-        MacOS::Xcode.prefix.to_s.include?("/Applications/Xcode.app/")
-    end
-  end
+  desc "Beam Delivery Simulation using Geant4"
+  homepage "http://www.pp.rhul.ac.uk/bdsim/manual/"
+  version "scoring-4D"
+  url "https://eramoisi@bitbucket.org/jairhul/bdsim.git", :branch =>"scoring-4D"
+  head "https://eramoisi@bitbucket.org/jairhul/bdsim.git"
 
   depends_on "cmake" => :build
-  depends_on "davix"
-  depends_on "fftw"
-  depends_on "gcc" # for gfortran
-  depends_on "graphviz"
-  depends_on "gsl"
-  # Temporarily depend on Homebrew libxml2 to work around a brew issue:
-  # https://github.com/Homebrew/brew/issues/5068
-  depends_on "libxml2" if MacOS.version >= :mojave
-  depends_on "lz4"
-  depends_on "openssl"
-  depends_on "pcre"
-  depends_on "python"
-  depends_on "tbb"
-  depends_on "xrootd"
-  depends_on "xz" # for LZMA
+  depends_on "bison"
+  depends_on "ulb-metronu/metronu/root"
+  depends_on "ulb-metronu/metronu/geant4"
 
   skip_clean "bin"
 
   def install
-    # Work around "error: no member named 'signbit' in the global namespace"
-    ENV.delete("SDKROOT") if DevelopmentTools.clang_build_version >= 900
-
-    # Freetype/afterimage/gl2ps/lz4 are vendored in the tarball, so are fine.
-    # However, this is still permitting the build process to make remote
-    # connections. As a hack, since upstream support it, we inreplace
-    # this file to "encourage" the connection over HTTPS rather than HTTP.
-    inreplace "cmake/modules/SearchInstalledSoftware.cmake",
-              "http://lcgpackages",
-              "https://lcgpackages"
-
-    py_exe = "/Users/chernals/miniconda3/envs/py27" # Utils.popen_read("which python3").strip
-    py_prefix = Utils.popen_read("/Users/chernals/miniconda3/envs/py27/bin/python -c 'import sys;print(sys.prefix)'").chomp
-    py_inc = Utils.popen_read("/Users/chernals/miniconda3/envs/py27/bin/python -c 'from distutils import sysconfig;print(sysconfig.get_python_inc(True))'").chomp
 
     args = std_cmake_args + %W[
       -DCLING_CXX_PATH=clang++
       -DCMAKE_INSTALL_ELISPDIR=#{elisp}
-      -DPYTHON_EXECUTABLE=#{py_exe}
-      -DPYTHON_INCLUDE_DIR=#{py_inc}
-      -DPYTHON_LIBRARY=#{py_prefix}/Python
-      -Dbuiltin_cfitsio=OFF
-      -Dbuiltin_freetype=ON
-      -Ddavix=ON
-      -Dfftw3=ON
-      -Dfitsio=OFF
-      -Dfortran=ON
-      -Dgdml=ON
-      -Dgnuinstall=ON
-      -Dimt=ON
-      -Dmathmore=ON
-      -Dminuit2=ON
-      -Dmysql=OFF
-      -Dpgsql=OFF
-      -Dpython=ON
-      -Droofit=ON
-      -Dssl=ON
-      -Dtmva=ON
-      -Dxrootd=ON
+      -DUSE_BOOST=ON
+      -DUSE_AWAKE=ON
     ]
 
-    cxx_version = (MacOS.version < :mojave) ? 14 : 17
+    cxx_version = 14
     args << "-DCMAKE_CXX_STANDARD=#{cxx_version}"
 
     mkdir "builddir" do
       system "cmake", "..", *args
 
-      # Work around superenv stripping out isysroot leading to errors with
-      # libsystem_symptoms.dylib (only available on >= 10.12) and
-      # libsystem_darwin.dylib (only available on >= 10.13)
-      if MacOS.version < :high_sierra
-        system "xcrun", "make", "install"
-      else
-        system "make", "install"
-      end
+      system "make", "install"
 
-      chmod 0755, Dir[bin/"*.*sh"]
     end
-  end
-
-  def caveats; <<~EOS
-    Because ROOT depends on several installation-dependent
-    environment variables to function properly, you should
-    add the following commands to your shell initialization
-    script (.bashrc/.profile/etc.), or call them directly
-    before using ROOT.
-
-    For bash users:
-      . #{HOMEBREW_PREFIX}/bin/thisroot.sh
-    For zsh users:
-      pushd #{HOMEBREW_PREFIX} >/dev/null; . bin/thisroot.sh; popd >/dev/null
-    For csh/tcsh users:
-      source #{HOMEBREW_PREFIX}/bin/thisroot.csh
-    For fish users:
-      . #{HOMEBREW_PREFIX}/bin/thisroot.fish
-  EOS
-  end
-
-  test do
-    (testpath/"test.C").write <<~EOS
-      #include <iostream>
-      void test() {
-        std::cout << "Hello, world!" << std::endl;
-      }
-    EOS
-
-    # Test ROOT command line mode
-    system "#{bin}/root", "-b", "-l", "-q", "-e", "gSystem->LoadAllLibraries(); 0"
-
-    # Test ROOT executable
-    (testpath/"test_root.bash").write <<~EOS
-      . #{bin}/thisroot.sh
-      root -l -b -n -q test.C
-    EOS
-    assert_equal "\nProcessing test.C...\nHello, world!\n",
-                 shell_output("/bin/bash test_root.bash")
-
-    (testpath/"test.cpp").write <<~EOS
-      #include <iostream>
-      #include <TString.h>
-      int main() {
-        std::cout << TString("Hello, world!") << std::endl;
-        return 0;
-      }
-    EOS
-
-    # Test linking
-    (testpath/"test_compile.bash").write <<~EOS
-      . #{bin}/thisroot.sh
-      $(root-config --cxx) $(root-config --cflags) $(root-config --libs) $(root-config --ldflags) test.cpp
-      ./a.out
-    EOS
-    assert_equal "Hello, world!\n",
-                 shell_output("/bin/bash test_compile.bash")
-
-    # Test Python module
-    ENV["PYTHONPATH"] = lib/"root"
-    system "python3", "-c", "import ROOT; ROOT.gSystem.LoadAllLibraries()"
   end
 end


### PR DESCRIPTION
il suffira de changer "scoring-4D" par "develop" lorsque les branches seront mergées.
Mais ceci permet deja de faire un installation complete de bdsim, geant4 et root provenant de ulb-metronu.